### PR TITLE
Update example.tf with correct defaults for example

### DIFF
--- a/examples/openvz/example.tf
+++ b/examples/openvz/example.tf
@@ -25,8 +25,8 @@ variable "storage" {
 
 variable "platform" {
   default = {
-    Falkenberg = "VMware"
-    Stockholm = "OpenVZ"
+    Falkenberg = "OpenVZ"
+    Stockholm = "VMware"
   }
 }
 


### PR DESCRIPTION
Falkenberg DC had VMware as default platform, causing terraform to create a Vmware resource instead of a OpenVZ one as intended.