### PR TITLE
Set resource connection info in resourceGlesysServerRead

### DIFF
--- a/examples/openvz-with-provisioner/example.tf
+++ b/examples/openvz-with-provisioner/example.tf
@@ -1,0 +1,95 @@
+# Set some variables 
+variable "datacenter" {
+  default = "Falkenberg"
+}
+
+# Instance defaults
+variable "description" {
+  default = "tf-test-norrland-"
+}
+
+variable "bw" {
+  default = 100
+  description = "Default bandwidth"
+}
+
+variable "mem" {
+  default = 2048
+  description = "Default memory"
+}
+
+variable "storage" {
+  default = 20
+  description = "Default storage"
+}
+
+variable "platform" {
+  default = {
+    Falkenberg = "OpenVZ"
+    Stockholm = "VMware"
+  }
+}
+
+variable "region" {
+  default = {
+    "0" = "Falkenberg"
+    "1" = "Stockholm"
+  }
+}
+
+variable "region_short" {
+  default = {
+    "0" = "fbg"
+    "1" = "sth"
+  }
+}
+
+variable "region_os" {
+  default = {
+    Falkenberg = "debian9"
+    Stockholm = "debian9"
+  }
+}
+
+variable "root_password" {
+ default = "hunter2!"
+}
+
+variable "template" {
+  default = {
+    debian8 = "Debian 8 64-bit"
+    debian9 = "Debian 9 64-bit"
+  }
+}
+
+# Create the server resource
+resource "glesys_server" "deb_64" {
+  count = 1
+  bandwidth = "${var.bw}"
+  cpu = 2
+  #datacenter = "${var.datacenter}"
+  datacenter = "${lookup(var.region, count.index)}"
+  description = "${var.description}deb Host terraform"
+  #hostname = "${var.description}deb8-${count.index}" # hostname with count index only
+  hostname = "${var.description}deb-${lookup(var.region_short, count.index)}-${count.index}" # hostname with short regionname and count
+  memory = "${var.mem}"
+  platform = "${lookup(var.platform,var.datacenter)}"
+  storage = "${var.storage}"
+  #template = "${lookup(var.template, lookup(var.region_os, lookup()var.datacenter))}"
+  template = "${lookup(var.template, lookup(var.region_os, lookup(var.region, count.index) ) )}"
+  password = "${var.root_password}"
+
+
+ provisioner "remote-exec" {
+  connection {
+   user = "root"
+   password = "${var.root_password}"
+   agent= "false"
+  }
+  inline =[
+   "date"
+  ]
+ }
+
+}
+

--- a/glesys/resource_glesys_server.go
+++ b/glesys/resource_glesys_server.go
@@ -149,6 +149,11 @@ func resourceGlesysServerRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("storage", srv.Storage)
 	d.Set("template", srv.Template)
 
+	d.SetConnInfo(map[string]string{
+                "type": "ssh",
+                "host": d.Get("ipv4_address").(string),
+        })
+	
 	return nil
 }
 


### PR DESCRIPTION
Resource connection info is used by Provisioner to connect to the resource on creation.