### PR TITLE
glesys_server: users -> user

### DIFF
--- a/examples/kvm/example.tf
+++ b/examples/kvm/example.tf
@@ -11,7 +11,7 @@ resource "glesys_server" "kvm" {
   platform = "KVM"
   template = "debian-10"
 
-  users {
+  user {
         username = "alice"
         publickeys = [
           "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINOCh8br7CwZDMGmINyJgBip943QXgkf7XdXrDMJf5Dl alice@example.com",
@@ -19,7 +19,7 @@ resource "glesys_server" "kvm" {
         ]
         password = "hunter3!"
   }
-  users {
+  user {
         username = "bob"
         publickeys = ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINOCh8br7CwZDMGmINyJgBip943QXgkf7XdXrDMJf5Dl bob@example.com"]
         password = "hunter333!"

--- a/glesys/resource_glesys_server.go
+++ b/glesys/resource_glesys_server.go
@@ -78,7 +78,7 @@ func resourceGlesysServer() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"users": {
+			"user": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
@@ -156,7 +156,7 @@ func resourceGlesysServerCreate(d *schema.ResourceData, m interface{}) error {
 	srv := buildServerParamStruct(d)
 
 	if srv.Platform == "KVM" {
-		usersList, err := expandUsers(d.Get("users").(*schema.Set).List())
+		usersList, err := expandUsers(d.Get("user").(*schema.Set).List())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Change the use of users to user, to make more sense when defining it in
the terraform manifest. `users` was a old implementation.