### PR TITLE
server: Ignore case sensitivity on hostname

### DIFF
--- a/glesys/resource_glesys_server.go
+++ b/glesys/resource_glesys_server.go
@@ -38,8 +38,9 @@ func resourceGlesysServer() *schema.Resource {
 				Optional: true,
 			},
 			"hostname": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				DiffSuppressFunc: IgnoreCase,
 			},
 			"ipv4_address": {
 				Type:     schema.TypeString,

--- a/glesys/supress.go
+++ b/glesys/supress.go
@@ -1,0 +1,11 @@
+package glesys
+
+import (
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func IgnoreCase(_, old, new string, _ *schema.ResourceData) bool {
+	return strings.ToLower(old) == strings.ToLower(new)
+}

--- a/glesys/supress.go
+++ b/glesys/supress.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
+// IgnoreCase check if the strings match when both are in lowercase
 func IgnoreCase(_, old, new string, _ *schema.ResourceData) bool {
 	return strings.ToLower(old) == strings.ToLower(new)
 }

--- a/go.sum
+++ b/go.sum
@@ -252,6 +252,7 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/miekg/dns v1.0.8/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0 h1:iGBIsUe3+HZ/AD/Vd7DErOt5sU9fa8Uj7A2s1aggv1Y=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
+github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=


### PR DESCRIPTION
When the API returns the hostname for a server in lowercase. Do
not mark it for update.